### PR TITLE
Add forwarding AsRef and AsMut macros

### DIFF
--- a/crates/impl-more/CHANGELOG.md
+++ b/crates/impl-more/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `forward_as_ref!`, `forward_as_mut!`, and `forward_as_ref_and_mut!` macros.
+
 ## 0.3.3
 
 - No significant changes since `0.3.2`.

--- a/crates/impl-more/README.md
+++ b/crates/impl-more/README.md
@@ -27,6 +27,8 @@ struct MyNewTypeStruct(String);
 
 impl_more::impl_as_ref!(MyNewTypeStruct => String);
 impl_more::impl_as_mut!(MyNewTypeStruct => String);
+impl_more::forward_as_ref!(MyNewTypeStruct => str);
+impl_more::forward_as_mut!(MyNewTypeStruct => str);
 
 impl_more::impl_deref!(MyNewTypeStruct => String);
 impl_more::impl_deref_mut!(MyNewTypeStruct);

--- a/crates/impl-more/src/as_ref.rs
+++ b/crates/impl-more/src/as_ref.rs
@@ -42,6 +42,68 @@ macro_rules! impl_as_ref {
     };
 }
 
+/// Implement [`AsRef`] by forwarding to a field's implementation.
+///
+/// The first argument is the struct to create the impl for and the second is the target type
+/// produced by the field's [`AsRef`] implementation.
+///
+/// # Examples
+/// With a newtype struct:
+/// ```
+/// use impl_more::forward_as_ref;
+///
+/// struct Foo(String);
+/// forward_as_ref!(Foo => str);
+///
+/// let foo = Foo("bar".to_owned());
+/// assert_eq!(foo.as_ref(), "bar");
+/// ```
+///
+/// With a named field struct and type parameters:
+/// ```
+/// use impl_more::forward_as_ref;
+///
+/// struct Foo<T> { inner: Vec<T> }
+/// forward_as_ref!(<T> in Foo<T> => inner: [T]);
+///
+/// let foo = Foo { inner: vec![1, 2, 3] };
+/// assert_eq!(foo.as_ref(), &[1, 2, 3]);
+/// ```
+#[macro_export]
+macro_rules! forward_as_ref {
+    (<$($generic:ident),+> in $this:ty => $target:ty) => {
+        impl <$($generic),+> ::core::convert::AsRef<$target> for $this {
+            fn as_ref(&self) -> &$target {
+                ::core::convert::AsRef::<$target>::as_ref(&self.0)
+            }
+        }
+    };
+
+    (<$($generic:ident),+> in $this:ty => $field:ident : $target:ty) => {
+        impl <$($generic),+> ::core::convert::AsRef<$target> for $this {
+            fn as_ref(&self) -> &$target {
+                ::core::convert::AsRef::<$target>::as_ref(&self.$field)
+            }
+        }
+    };
+
+    ($this:ty => $target:ty) => {
+        impl ::core::convert::AsRef<$target> for $this {
+            fn as_ref(&self) -> &$target {
+                ::core::convert::AsRef::<$target>::as_ref(&self.0)
+            }
+        }
+    };
+
+    ($this:ty => $field:ident : $target:ty) => {
+        impl ::core::convert::AsRef<$target> for $this {
+            fn as_ref(&self) -> &$target {
+                ::core::convert::AsRef::<$target>::as_ref(&self.$field)
+            }
+        }
+    };
+}
+
 /// Implement [`AsMut`] for a struct.
 ///
 /// The first argument is that of the struct to create the impl for and the second is the type to
@@ -94,4 +156,159 @@ macro_rules! impl_as_mut {
             }
         }
     };
+}
+
+/// Implement [`AsMut`] by forwarding to a field's implementation.
+///
+/// The first argument is the struct to create the impl for and the second is the target type
+/// produced by the field's [`AsMut`] implementation.
+///
+/// # Examples
+/// With a newtype struct:
+/// ```
+/// use impl_more::forward_as_mut;
+///
+/// struct Foo(String);
+/// forward_as_mut!(Foo => str);
+///
+/// let mut foo = Foo("bar".to_owned());
+/// foo.as_mut().make_ascii_uppercase();
+///
+/// assert_eq!(foo.0, "BAR");
+/// ```
+///
+/// With a named field struct and type parameters:
+/// ```
+/// use impl_more::forward_as_mut;
+///
+/// struct Foo<T> { inner: Vec<T> }
+/// forward_as_mut!(<T> in Foo<T> => inner: [T]);
+///
+/// let mut foo = Foo { inner: vec![1, 2, 3] };
+/// foo.as_mut().reverse();
+///
+/// assert_eq!(foo.inner, [3, 2, 1]);
+/// ```
+#[macro_export]
+macro_rules! forward_as_mut {
+    (<$($generic:ident),+> in $this:ty => $target:ty) => {
+        impl <$($generic),+> ::core::convert::AsMut<$target> for $this {
+            fn as_mut(&mut self) -> &mut $target {
+                ::core::convert::AsMut::<$target>::as_mut(&mut self.0)
+            }
+        }
+    };
+
+    (<$($generic:ident),+> in $this:ty => $field:ident : $target:ty) => {
+        impl <$($generic),+> ::core::convert::AsMut<$target> for $this {
+            fn as_mut(&mut self) -> &mut $target {
+                ::core::convert::AsMut::<$target>::as_mut(&mut self.$field)
+            }
+        }
+    };
+
+    ($this:ty => $target:ty) => {
+        impl ::core::convert::AsMut<$target> for $this {
+            fn as_mut(&mut self) -> &mut $target {
+                ::core::convert::AsMut::<$target>::as_mut(&mut self.0)
+            }
+        }
+    };
+
+    ($this:ty => $field:ident : $target:ty) => {
+        impl ::core::convert::AsMut<$target> for $this {
+            fn as_mut(&mut self) -> &mut $target {
+                ::core::convert::AsMut::<$target>::as_mut(&mut self.$field)
+            }
+        }
+    };
+}
+
+/// Implement [`AsRef`] and [`AsMut`] by forwarding to a field's implementations.
+///
+/// This macro has the same type parameter support and format as [`forward_as_ref`].
+///
+/// # Examples
+/// ```
+/// use impl_more::forward_as_ref_and_mut;
+///
+/// struct Foo(String);
+/// forward_as_ref_and_mut!(Foo => str);
+///
+/// let mut foo = Foo("bar".to_owned());
+/// foo.as_mut().make_ascii_uppercase();
+///
+/// assert_eq!(foo.as_ref(), "BAR");
+/// ```
+///
+/// [`forward_as_ref`]: crate::forward_as_ref
+#[macro_export]
+macro_rules! forward_as_ref_and_mut {
+    (<$($generic:ident),+> in $this:ty => $target:ty) => {
+        $crate::forward_as_ref!(<$($generic),+> in $this => $target);
+        $crate::forward_as_mut!(<$($generic),+> in $this => $target);
+    };
+
+    (<$($generic:ident),+> in $this:ty => $field:ident : $target:ty) => {
+        $crate::forward_as_ref!(<$($generic),+> in $this => $field: $target);
+        $crate::forward_as_mut!(<$($generic),+> in $this => $field: $target);
+    };
+
+    ($this:ty => $target:ty) => {
+        $crate::forward_as_ref!($this => $target);
+        $crate::forward_as_mut!($this => $target);
+    };
+
+    ($this:ty => $field:ident : $target:ty) => {
+        $crate::forward_as_ref!($this => $field: $target);
+        $crate::forward_as_mut!($this => $field: $target);
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{string::String, vec, vec::Vec};
+
+    struct Newtype(String);
+    forward_as_ref!(Newtype => str);
+    forward_as_mut!(Newtype => str);
+
+    struct Generic<T>(Vec<T>);
+    forward_as_ref!(<T> in Generic<T> => [T]);
+    forward_as_mut!(<T> in Generic<T> => [T]);
+
+    struct GenericNamed<T> {
+        inner: Vec<T>,
+    }
+    forward_as_ref_and_mut!(<T> in GenericNamed<T> => inner: [T]);
+
+    static_assertions::assert_impl_all!(Newtype: AsRef<str>, AsMut<str>);
+    static_assertions::assert_impl_all!(Generic<usize>: AsRef<[usize]>, AsMut<[usize]>);
+    static_assertions::assert_impl_all!(GenericNamed<usize>: AsRef<[usize]>, AsMut<[usize]>);
+
+    #[test]
+    fn forwards_newtype() {
+        let mut value = Newtype("hello".into());
+        AsMut::<str>::as_mut(&mut value).make_ascii_uppercase();
+
+        assert_eq!(AsRef::<str>::as_ref(&value), "HELLO");
+    }
+
+    #[test]
+    fn forwards_generic_newtype() {
+        let mut value = Generic(vec![1, 2, 3]);
+        AsMut::<[usize]>::as_mut(&mut value).reverse();
+
+        assert_eq!(AsRef::<[usize]>::as_ref(&value), &[3, 2, 1]);
+    }
+
+    #[test]
+    fn forwards_generic_named_field() {
+        let mut value = GenericNamed {
+            inner: vec![1, 2, 3],
+        };
+        AsMut::<[usize]>::as_mut(&mut value).reverse();
+
+        assert_eq!(AsRef::<[usize]>::as_ref(&value), &[3, 2, 1]);
+    }
 }

--- a/crates/impl-more/src/lib.rs
+++ b/crates/impl-more/src/lib.rs
@@ -12,6 +12,8 @@
 //!
 //! impl_more::impl_as_ref!(MyNewTypeStruct => String);
 //! impl_more::impl_as_mut!(MyNewTypeStruct => String);
+//! impl_more::forward_as_ref!(MyNewTypeStruct => str);
+//! impl_more::forward_as_mut!(MyNewTypeStruct => str);
 //!
 //! impl_more::impl_deref!(MyNewTypeStruct => String);
 //! impl_more::impl_deref_mut!(MyNewTypeStruct);

--- a/ensure-no-std/src/compat_test.rs
+++ b/ensure-no-std/src/compat_test.rs
@@ -1,10 +1,12 @@
-use alloc::string::String;
+use alloc::{string::String, vec::Vec};
 
 #[derive(Debug, Clone)]
 struct Foo(String);
 
 impl_more::impl_as_ref!(Foo => String);
 impl_more::impl_as_mut!(Foo => String);
+impl_more::forward_as_ref!(Foo => str);
+impl_more::forward_as_mut!(Foo => str);
 
 impl_more::impl_deref!(Foo => String);
 impl_more::impl_deref_mut!(Foo);
@@ -19,6 +21,7 @@ struct Bar {
     inner: String,
 }
 
+impl_more::forward_as_ref_and_mut!(Bar => inner: str);
 impl_more::forward_display!(Bar => inner);
 
 #[derive(Debug)]
@@ -35,6 +38,11 @@ struct Baz<T> {
 }
 
 impl_more::forward_display!(<T> in Baz<T> => inner);
+
+#[derive(Debug, Clone)]
+struct Qux<T>(Vec<T>);
+
+impl_more::forward_as_ref_and_mut!(<T> in Qux<T> => [T]);
 
 #[derive(Debug)]
 struct LeafErr;


### PR DESCRIPTION
## Summary

- add `forward_as_ref!` and `forward_as_mut!` for newtype, named-field, and generic wrappers
- add `forward_as_ref_and_mut!` as the combined companion to `forward_deref_and_mut!`
- document the new API, regenerate the README, and record it in the changelog
- exercise the expansions in unit tests and the no-std compatibility harness

## Why

`impl_as_ref!` and `impl_as_mut!` can expose a field's exact type, but cannot forward conversions such as `String: AsRef<str>` or `Vec<T>: AsRef<[T]>`. These macros cover that gap without requiring a procedural derive.

## Validation

- `nix develop -c just check`
- `nix develop -c just test`
- `nix develop -c just test-docs`
- Rust 1.58 path-dependency smoke check covering newtype, named-field, and generic forms
