### PR TITLE
Add forward_from_str! macro

### DIFF
--- a/crates/impl-more/CHANGELOG.md
+++ b/crates/impl-more/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `forward_from_str!` macro.
+
 ## 0.3.4
 
 - Add `forward_as_ref!`, `forward_as_mut!`, and `forward_as_ref_and_mut!` macros.

--- a/crates/impl-more/README.md
+++ b/crates/impl-more/README.md
@@ -38,6 +38,7 @@ impl_more::impl_deref_mut!(MyNewTypeStruct);
 impl_more::impl_from!(String => MyNewTypeStruct);
 impl_more::impl_into!(MyNewTypeStruct => String);
 
+impl_more::forward_display!(MyNewTypeStruct);
 impl_more::forward_from_str!(MyNewTypeStruct => String);
 
 enum MyEnum {

--- a/crates/impl-more/README.md
+++ b/crates/impl-more/README.md
@@ -37,6 +37,7 @@ impl_more::impl_deref_mut!(MyNewTypeStruct);
 
 impl_more::impl_from!(String => MyNewTypeStruct);
 impl_more::impl_into!(MyNewTypeStruct => String);
+impl_more::forward_from_str!(MyNewTypeStruct => String);
 
 enum MyEnum {
     Bar,

--- a/crates/impl-more/README.md
+++ b/crates/impl-more/README.md
@@ -37,6 +37,7 @@ impl_more::impl_deref_mut!(MyNewTypeStruct);
 
 impl_more::impl_from!(String => MyNewTypeStruct);
 impl_more::impl_into!(MyNewTypeStruct => String);
+
 impl_more::forward_from_str!(MyNewTypeStruct => String);
 
 enum MyEnum {

--- a/crates/impl-more/src/from_str.rs
+++ b/crates/impl-more/src/from_str.rs
@@ -1,0 +1,136 @@
+/// Implement [`FromStr`] by forwarding to a field's implementation.
+///
+/// The first argument is the struct to create the impl for and the second is the field type whose
+/// [`FromStr`] implementation is used.
+///
+/// # Examples
+/// With a newtype struct:
+/// ```
+/// use impl_more::forward_from_str;
+///
+/// #[derive(Debug, PartialEq)]
+/// struct Port(u16);
+/// forward_from_str!(Port => u16);
+///
+/// assert_eq!("8080".parse(), Ok(Port(8080)));
+/// ```
+///
+/// With a named field struct and type parameters:
+/// ```
+/// use impl_more::forward_from_str;
+///
+/// #[derive(Debug, PartialEq)]
+/// struct Value<T> { inner: T }
+/// forward_from_str!(<T> in Value<T> => inner: T);
+///
+/// assert_eq!("true".parse(), Ok(Value { inner: true }));
+/// ```
+///
+/// [`FromStr`]: core::str::FromStr
+#[macro_export]
+macro_rules! forward_from_str {
+    (<$($generic:ident),+> in $this:ty => $inner:ty $(,)?) => {
+        impl <$($generic),+> ::core::str::FromStr for $this
+        where
+            $inner: ::core::str::FromStr,
+        {
+            type Err = <$inner as ::core::str::FromStr>::Err;
+
+            fn from_str(value: &str) -> ::core::result::Result<Self, Self::Err> {
+                <$inner as ::core::str::FromStr>::from_str(value).map(Self)
+            }
+        }
+    };
+
+    (<$($generic:ident),+> in $this:ty => $field:ident : $inner:ty $(,)?) => {
+        impl <$($generic),+> ::core::str::FromStr for $this
+        where
+            $inner: ::core::str::FromStr,
+        {
+            type Err = <$inner as ::core::str::FromStr>::Err;
+
+            fn from_str(value: &str) -> ::core::result::Result<Self, Self::Err> {
+                <$inner as ::core::str::FromStr>::from_str(value)
+                    .map(|$field| Self { $field })
+            }
+        }
+    };
+
+    ($this:ty => $inner:ty $(,)?) => {
+        impl ::core::str::FromStr for $this {
+            type Err = <$inner as ::core::str::FromStr>::Err;
+
+            fn from_str(value: &str) -> ::core::result::Result<Self, Self::Err> {
+                <$inner as ::core::str::FromStr>::from_str(value).map(Self)
+            }
+        }
+    };
+
+    ($this:ty => $field:ident : $inner:ty $(,)?) => {
+        impl ::core::str::FromStr for $this {
+            type Err = <$inner as ::core::str::FromStr>::Err;
+
+            fn from_str(value: &str) -> ::core::result::Result<Self, Self::Err> {
+                <$inner as ::core::str::FromStr>::from_str(value)
+                    .map(|$field| Self { $field })
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use core::{num::ParseIntError, str::FromStr as _};
+
+    #[derive(Debug, PartialEq)]
+    struct Newtype(u16);
+    forward_from_str!(Newtype => u16);
+
+    #[derive(Debug, PartialEq)]
+    struct Named {
+        inner: bool,
+    }
+    forward_from_str!(Named => inner: bool);
+
+    #[derive(Debug, PartialEq)]
+    struct Generic<T>(T);
+    forward_from_str!(<T> in Generic<T> => T);
+
+    #[derive(Debug, PartialEq)]
+    struct GenericNamed<T> {
+        inner: T,
+    }
+    forward_from_str!(<T> in GenericNamed<T> => inner: T);
+
+    static_assertions::assert_impl_all!(Newtype: core::str::FromStr<Err = ParseIntError>);
+    static_assertions::assert_impl_all!(Named: core::str::FromStr<Err = core::str::ParseBoolError>);
+    static_assertions::assert_impl_all!(Generic<u16>: core::str::FromStr<Err = ParseIntError>);
+    static_assertions::assert_impl_all!(
+        GenericNamed<bool>: core::str::FromStr<Err = core::str::ParseBoolError>
+    );
+
+    #[test]
+    fn forwards_newtype() {
+        assert_eq!(Newtype::from_str("8080"), Ok(Newtype(8080)));
+        assert!(Newtype::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn forwards_named_field() {
+        assert_eq!(Named::from_str("true"), Ok(Named { inner: true }));
+        assert!(Named::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn forwards_generic_newtype() {
+        assert_eq!(Generic::<u16>::from_str("8080"), Ok(Generic(8080)));
+    }
+
+    #[test]
+    fn forwards_generic_named_field() {
+        assert_eq!(
+            GenericNamed::<bool>::from_str("true"),
+            Ok(GenericNamed { inner: true })
+        );
+    }
+}

--- a/crates/impl-more/src/lib.rs
+++ b/crates/impl-more/src/lib.rs
@@ -22,6 +22,7 @@
 //!
 //! impl_more::impl_from!(String => MyNewTypeStruct);
 //! impl_more::impl_into!(MyNewTypeStruct => String);
+//! impl_more::forward_from_str!(MyNewTypeStruct => String);
 //!
 //! enum MyEnum {
 //!     Bar,
@@ -100,6 +101,8 @@ mod display;
 mod error;
 #[macro_use]
 mod from;
+#[macro_use]
+mod from_str;
 
 #[cfg(test)]
 mod tests {

--- a/crates/impl-more/src/lib.rs
+++ b/crates/impl-more/src/lib.rs
@@ -23,6 +23,7 @@
 //! impl_more::impl_from!(String => MyNewTypeStruct);
 //! impl_more::impl_into!(MyNewTypeStruct => String);
 //!
+//! impl_more::forward_display!(MyNewTypeStruct);
 //! impl_more::forward_from_str!(MyNewTypeStruct => String);
 //!
 //! enum MyEnum {

--- a/crates/impl-more/src/lib.rs
+++ b/crates/impl-more/src/lib.rs
@@ -22,6 +22,7 @@
 //!
 //! impl_more::impl_from!(String => MyNewTypeStruct);
 //! impl_more::impl_into!(MyNewTypeStruct => String);
+//!
 //! impl_more::forward_from_str!(MyNewTypeStruct => String);
 //!
 //! enum MyEnum {

--- a/ensure-no-std/src/compat_test.rs
+++ b/ensure-no-std/src/compat_test.rs
@@ -13,6 +13,7 @@ impl_more::impl_deref_mut!(Foo);
 
 impl_more::impl_from!(String => Foo);
 impl_more::impl_into!(Foo => String);
+impl_more::forward_from_str!(Foo => String);
 
 impl_more::forward_display!(Foo);
 
@@ -37,6 +38,7 @@ struct Baz<T> {
     inner: T,
 }
 
+impl_more::forward_from_str!(<T> in Baz<T> => inner: T);
 impl_more::forward_display!(<T> in Baz<T> => inner);
 
 #[derive(Debug, Clone)]

--- a/ensure-no-std/src/compat_test.rs
+++ b/ensure-no-std/src/compat_test.rs
@@ -13,9 +13,9 @@ impl_more::impl_deref_mut!(Foo);
 
 impl_more::impl_from!(String => Foo);
 impl_more::impl_into!(Foo => String);
-impl_more::forward_from_str!(Foo => String);
 
 impl_more::forward_display!(Foo);
+impl_more::forward_from_str!(Foo => String);
 
 #[derive(Debug, Clone)]
 struct Bar {
@@ -38,8 +38,8 @@ struct Baz<T> {
     inner: T,
 }
 
-impl_more::forward_from_str!(<T> in Baz<T> => inner: T);
 impl_more::forward_display!(<T> in Baz<T> => inner);
+impl_more::forward_from_str!(<T> in Baz<T> => inner: T);
 
 #[derive(Debug, Clone)]
 struct Qux<T>(Vec<T>);


### PR DESCRIPTION
## Summary

- Add `forward_from_str!` for tuple and named-field wrappers.
- Support generic wrappers using the existing `<T> in Wrapper<T>` syntax.
- Preserve the inner type's `FromStr::Err` without conversion.
- Document the macro and exercise it in the `no_std` compatibility harness.

## Impact

Wrapper types can delegate string parsing to their inner field without manually writing a `FromStr` implementation. The emitted implementation uses `core` and remains `no_std` compatible.

## Validation

- `nix develop -c just check`
- `nix develop -c just test`
- `nix develop -c just test-docs`
- Direct Rust 1.58 compilation of the library and tuple/generic named macro expansions.
