### PR TITLE
chore: align Dependabot update schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,4 @@ updates:
   - package-ecosystem: cargo
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly


### PR DESCRIPTION
Align Dependabot schedules with the repository baseline.

This changes only `.github/dependabot.yml`; it does not update Cargo.lock or Nix input hashes.
